### PR TITLE
fix parser to not avoid 50% of tags

### DIFF
--- a/adif_parser.php
+++ b/adif_parser.php
@@ -88,6 +88,7 @@ class ADIF_Parser
 					$len--;
 					$a++;
 				};
+				$a--;
 				$return[strtolower($tag_name)] = $value;
 			};
 		};


### PR DESCRIPTION
Actually adif parser read only 50% of tags because it avoid a half of "<" simbols and once it reach the next "<" a lot of information is missed